### PR TITLE
fix(deps): update babel dependencies

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ $ npm install automatic-semicolon-insertion
 ## Usage
 
 ```js
-import asi from 'automatic-semicolon-insertion';
-import { parse } from '@babel/parser';
+import asi from "automatic-semicolon-insertion";
+import { parse } from "@codemod/parser";
 
-const source = 'let a = class {}'; // should have a semicolon after it
+const source = "let a = class {}"; // should have a semicolon after it
 
 console.log(asi(source, parse(source)));
 

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   },
   "homepage": "https://github.com/eventualbuddha/automatic-semicolon-insertion#readme",
   "dependencies": {
-    "@babel/traverse": "^7.5.5",
-    "@babel/types": "^7.5.5"
+    "@babel/traverse": "^7.6.2",
+    "@babel/types": "^7.6.1"
   },
   "devDependencies": {
-    "@babel/parser": "^7.5.5",
+    "@codemod/parser": "^1.0.3",
     "@types/babel__traverse": "^7.0.7",
     "@types/jest": "^24.0.15",
     "@types/node": "^12.6.8",
@@ -45,7 +45,7 @@
     "typescript": "^3.5.3"
   },
   "resolutions": {
-    "**/@babel/types": "7.5.5"
+    "**/@babel/types": "7.6.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/test/insertions.test.ts
+++ b/test/insertions.test.ts
@@ -1,15 +1,9 @@
 import process, { Insertion, Removal } from '../src';
-import { parse, ParserOptions } from '@babel/parser';
+import { parse } from '@codemod/parser';
 
 describe('insertions', () => {
   function check(source: string, expected: Array<Insertion>) {
-    const ast = parse(source, {
-      sourceType: 'module',
-      tokens: true,
-      // TODO: remove this `keyof` hack once `allowUndeclaredExports` is included in typings
-      // https://github.com/babel/babel/pull/10263
-      ['allowUndeclaredExports' as keyof ParserOptions]: true
-    });
+    const ast = parse(source, { tokens: true });
     const { insertions } = process(source, ast);
     expect(expected).toEqual(insertions);
   }
@@ -20,16 +14,13 @@ describe('insertions', () => {
         index: 3,
         content: ';'
       }
-    ])
-  );
-  
+    ]));
+
   it('does not insert a semicolon after statements that have them', () =>
-    check('foo;', [])
-  );
+    check('foo;', []));
 
   it('does not insert semicolons after the init of a `for` loop', () =>
-    check('for (var i = 0; i < 2; i++) {}', [])
-  );
+    check('for (var i = 0; i < 2; i++) {}', []));
 
   it('inserts semicolons after `return` statements', () =>
     check('function foo() { return 21 }', [
@@ -37,8 +28,7 @@ describe('insertions', () => {
         index: 26,
         content: ';'
       }
-    ])
-  );
+    ]));
 
   it('inserts semicolons after `throw` statements', () =>
     check('throw 1', [
@@ -46,8 +36,7 @@ describe('insertions', () => {
         index: 7,
         content: ';'
       }
-    ])
-  );
+    ]));
 
   it('inserts semicolons after `continue` statements', () =>
     check('for (;;) { continue }', [
@@ -55,8 +44,7 @@ describe('insertions', () => {
         index: 19,
         content: ';'
       }
-    ])
-  );
+    ]));
 
   it('inserts semicolons after `do-while` statements', () =>
     check('do {} while (true)', [
@@ -64,8 +52,7 @@ describe('insertions', () => {
         index: 18,
         content: ';'
       }
-    ])
-  );
+    ]));
 
   it('inserts semicolons after `break` statements', () =>
     check('for (;;) { break }', [
@@ -73,8 +60,7 @@ describe('insertions', () => {
         index: 16,
         content: ';'
       }
-    ])
-  );
+    ]));
 
   it('inserts semicolons after `debugger` statements', () =>
     check('debugger', [
@@ -82,8 +68,7 @@ describe('insertions', () => {
         index: 8,
         content: ';'
       }
-    ])
-  );
+    ]));
 
   it('inserts semicolons after `import` statements', () =>
     check('import "foo"', [
@@ -91,8 +76,7 @@ describe('insertions', () => {
         index: 12,
         content: ';'
       }
-    ])
-  );
+    ]));
 
   it('inserts semicolons after named `export` statements', () =>
     check('export { a }', [
@@ -100,8 +84,7 @@ describe('insertions', () => {
         index: 12,
         content: ';'
       }
-    ])
-  );
+    ]));
 
   it('inserts semicolons after `export` with a declaration statement', () =>
     check('export var a = 1', [
@@ -109,12 +92,10 @@ describe('insertions', () => {
         index: 16,
         content: ';'
       }
-    ])
-  );
+    ]));
 
   it('does not insert semicolons after `export` with a function declaration', () =>
-    check('export function foo(){}', [])
-  );
+    check('export function foo(){}', []));
 
   it('inserts semicolons after class expression export default statements', () =>
     check('export default class {}', [
@@ -122,8 +103,7 @@ describe('insertions', () => {
         index: 23,
         content: ';'
       }
-    ])
-  );
+    ]));
 });
 
 describe('removals', () => {
@@ -139,24 +119,23 @@ describe('removals', () => {
         start: 2,
         end: 3
       }
-    ])
-  );
+    ]));
 
-  it('leaves empty statements in `for` loops', () =>
-    check('for (;;);', [])
-  );
-  
+  it('leaves empty statements in `for` loops', () => check('for (;;);', []));
+
   it('removes semicolons after method definitions', () =>
-    check('class A { a() {}; }', [{
-      start: 16,
-      end: 17
-    }])
-  );
+    check('class A { a() {}; }', [
+      {
+        start: 16,
+        end: 17
+      }
+    ]));
 
   it('removes semicolons after the start of a class body', () =>
-    check('class A {; a() { b(); } }', [{
-      start: 9,
-      end: 10
-    }])
-  );
+    check('class A {; a() { b(); } }', [
+      {
+        start: 9,
+        end: 10
+      }
+    ]));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,16 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/generator@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz#dac8a3c2df118334c2a29ff3446da1636a8f8c03"
+  integrity sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==
+  dependencies:
+    "@babel/types" "^7.6.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
 "@babel/helper-function-name@^7.1.0":
   version "7.1.0"
   resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
@@ -91,6 +101,11 @@
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
   integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
 
+"@babel/parser@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz#205e9c95e16ba3b8b96090677a67c9d6075b70a1"
+  integrity sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==
+
 "@babel/plugin-syntax-object-rest-spread@^7.0.0":
   version "7.2.0"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
@@ -122,10 +137,25 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@7.5.5", "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5":
-  version "7.5.5"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
-  integrity sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+"@babel/traverse@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz#b0e2bfd401d339ce0e6c05690206d1e11502ce2c"
+  integrity sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.2"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.6.2"
+    "@babel/types" "^7.6.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
+"@babel/types@7.6.1", "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0", "@babel/types@^7.6.1":
+  version "7.6.1"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
+  integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -138,6 +168,13 @@
   dependencies:
     exec-sh "^0.3.2"
     minimist "^1.2.0"
+
+"@codemod/parser@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@codemod/parser/-/parser-1.0.3.tgz#e832fcb565f3855800f7d0b6235ae13aaf48894b"
+  integrity sha512-R9GvW0mtPPVKhsmi40UbCPpsdWyeShlk+oWFP0WSjELfLljF5NMlm6JERcdy0OY6I4pxLTWHqZ/AWZD0uyL01A==
+  dependencies:
+    "@babel/parser" "^7.5.5"
 
 "@jest/console@^24.7.1":
   version "24.7.1"


### PR DESCRIPTION

This also replaces `@babel/parser` with `@codemod/parser` to make it easier to parse everything.