### PR TITLE
fix(package): make importing work

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,12 +1,25 @@
-// For a detailed explanation regarding each configuration property, visit:
-// https://jestjs.io/docs/en/configuration.html
-
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
 
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
 
   // The test environment that will be used for testing
   testEnvironment: 'node',
+
+  globals: {
+    'ts-jest': {
+      // Both of these seem to be needed for the tests to run as ES modules.
+      useESM: true,
+      babelConfig: true,
+    },
+  },
+
+  // Allow importing with `.js` extension and map it to TypeScript in tests.
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.18.2",
         "@babel/types": "^7.18.4"
       },
       "devDependencies": {
@@ -52,6 +51,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
       "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.16.7"
       },
@@ -111,6 +111,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
       "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.2",
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -151,6 +152,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
       "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -159,6 +161,7 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
       "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.16.7",
         "@babel/types": "^7.17.0"
@@ -171,6 +174,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
       "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.7"
       },
@@ -234,6 +238,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
       "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.7"
       },
@@ -276,6 +281,7 @@
       "version": "7.17.12",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
       "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
@@ -289,6 +295,7 @@
       "version": "7.18.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
       "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -462,6 +469,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
       "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
         "@babel/parser": "^7.16.7",
@@ -475,6 +483,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
       "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
         "@babel/generator": "^7.18.2",
@@ -1704,6 +1713,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
       "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1717,6 +1727,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
       "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1725,6 +1736,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
       "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1732,12 +1744,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
       "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1912,6 +1926,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2224,6 +2239,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2285,6 +2301,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -2292,7 +2309,8 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2327,6 +2345,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2418,6 +2437,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -2763,6 +2783,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2789,6 +2810,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5494,7 +5516,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -5513,6 +5536,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -5674,7 +5698,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6164,6 +6189,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -6538,6 +6564,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
       "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.16.7"
       }
@@ -6583,6 +6610,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
       "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.2",
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -6612,12 +6640,14 @@
     "@babel/helper-environment-visitor": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-      "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ=="
+      "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
+      "dev": true
     },
     "@babel/helper-function-name": {
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
       "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
         "@babel/types": "^7.17.0"
@@ -6627,6 +6657,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
       "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.16.7"
       }
@@ -6675,6 +6706,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
       "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.16.7"
       }
@@ -6705,6 +6737,7 @@
       "version": "7.17.12",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
       "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
@@ -6714,7 +6747,8 @@
     "@babel/parser": {
       "version": "7.18.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-      "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow=="
+      "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
+      "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -6837,6 +6871,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
       "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "@babel/parser": "^7.16.7",
@@ -6847,6 +6882,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
       "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "@babel/generator": "^7.18.2",
@@ -7803,6 +7839,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
       "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -7812,22 +7849,26 @@
     "@jridgewell/resolve-uri": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA=="
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "dev": true
     },
     "@jridgewell/set-array": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+      "dev": true
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
       "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -7993,6 +8034,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -8221,6 +8263,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -8272,6 +8315,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -8279,7 +8323,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -8311,6 +8356,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -8375,7 +8421,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.1",
@@ -8626,7 +8673,8 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -8646,7 +8694,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -10712,7 +10761,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -10727,7 +10777,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -10849,7 +10900,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -11211,6 +11263,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,12 +33,11 @@
   ],
   "scripts": {
     "build": "./script/build",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@babel/traverse": "^7.18.2",
     "@babel/types": "^7.18.4"
   },
   "devDependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
-import { process, Insertion, Removal } from '.';
 import { parse } from '@codemod/parser';
+import { Insertion, process, Removal } from './index.js';
 
 describe('insertions', () => {
   function check(source: string, expected: Array<Insertion>) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { strict as assert } from 'assert';
 import * as t from '@babel/types';
-import traverse, { NodePath } from '@babel/traverse';
+import { strict as assert } from 'assert';
+import { traverse } from './traverse.js';
 
 // This should be defined in `@babel/types` but isn't.
 export interface Token {
@@ -40,6 +40,10 @@ export interface Changes {
   removals: Array<Removal>;
 }
 
+/**
+ * Process a source code string and its AST to produce source code insertions
+ * and removals.
+ */
 export function process(source: string, ast: t.File): Changes {
   assert(
     ast.tokens,
@@ -50,8 +54,7 @@ export function process(source: string, ast: t.File): Changes {
   const removals: Array<Removal> = [];
 
   traverse(ast, {
-    VariableDeclaration(path: NodePath<t.VariableDeclaration>): void {
-      const { node, parent } = path;
+    VariableDeclaration(node: t.VariableDeclaration, parent?: t.Node): void {
       const isForInit =
         (t.isForStatement(parent) && parent.init === node) ||
         ((t.isForInStatement(parent) || t.isForOfStatement(parent)) &&
@@ -62,50 +65,49 @@ export function process(source: string, ast: t.File): Changes {
       }
     },
 
-    ExpressionStatement(path: NodePath<t.ExpressionStatement>): void {
-      checkForSemicolon(path.node);
+    ExpressionStatement(node: t.ExpressionStatement): void {
+      checkForSemicolon(node);
     },
 
-    ReturnStatement(path: NodePath<t.ReturnStatement>): void {
-      checkForSemicolon(path.node);
+    ReturnStatement(node: t.ReturnStatement): void {
+      checkForSemicolon(node);
     },
 
-    ThrowStatement(path: NodePath<t.ThrowStatement>): void {
-      checkForSemicolon(path.node);
+    ThrowStatement(node: t.ThrowStatement): void {
+      checkForSemicolon(node);
     },
 
-    DoWhileStatement(path: NodePath<t.DoWhileStatement>): void {
-      checkForSemicolon(path.node);
+    DoWhileStatement(node: t.DoWhileStatement): void {
+      checkForSemicolon(node);
     },
 
-    DebuggerStatement(path: NodePath<t.DebuggerStatement>): void {
-      checkForSemicolon(path.node);
+    DebuggerStatement(node: t.DebuggerStatement): void {
+      checkForSemicolon(node);
     },
 
-    BreakStatement(path: NodePath<t.BreakStatement>): void {
-      checkForSemicolon(path.node);
+    BreakStatement(node: t.BreakStatement): void {
+      checkForSemicolon(node);
     },
 
-    ContinueStatement(path: NodePath<t.ContinueStatement>): void {
-      checkForSemicolon(path.node);
+    ContinueStatement(node: t.ContinueStatement): void {
+      checkForSemicolon(node);
     },
 
-    ImportDeclaration(path: NodePath<t.ImportDeclaration>): void {
-      checkForSemicolon(path.node);
+    ImportDeclaration(node: t.ImportDeclaration): void {
+      checkForSemicolon(node);
     },
 
-    ExportAllDeclaration(path: NodePath<t.ExportAllDeclaration>): void {
-      checkForSemicolon(path.node);
+    ExportAllDeclaration(node: t.ExportAllDeclaration): void {
+      checkForSemicolon(node);
     },
 
-    ExportNamedDeclaration(path: NodePath<t.ExportNamedDeclaration>): void {
-      if (!path.node.declaration) {
-        checkForSemicolon(path.node);
+    ExportNamedDeclaration(node: t.ExportNamedDeclaration): void {
+      if (!node.declaration) {
+        checkForSemicolon(node);
       }
     },
 
-    ExportDefaultDeclaration(path: NodePath<t.ExportDefaultDeclaration>): void {
-      const { node } = path;
+    ExportDefaultDeclaration(node: t.ExportDefaultDeclaration): void {
       const { declaration } = node;
 
       if (
@@ -120,9 +122,7 @@ export function process(source: string, ast: t.File): Changes {
       }
     },
 
-    EmptyStatement(path: NodePath<t.EmptyStatement>): void {
-      const { node, parent } = path;
-
+    EmptyStatement(node: t.EmptyStatement, parent?: t.Node): void {
       if (
         !t.isForStatement(parent) &&
         !t.isForOfStatement(parent) &&
@@ -134,12 +134,12 @@ export function process(source: string, ast: t.File): Changes {
       }
     },
 
-    ClassBody(path: NodePath<t.ClassBody>): void {
-      checkClassBodyForSemicolon(tokenAfterToken(firstTokenOfNode(path.node)));
+    ClassBody(node: t.ClassBody): void {
+      checkClassBodyForSemicolon(tokenAfterToken(firstTokenOfNode(node)));
     },
 
-    ClassMethod(path: NodePath<t.ClassMethod>): void {
-      checkClassBodyForSemicolon(tokenAfterToken(lastTokenOfNode(path.node)));
+    ClassMethod(node: t.ClassMethod): void {
+      checkClassBodyForSemicolon(tokenAfterToken(lastTokenOfNode(node)));
     },
   });
 

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -1,0 +1,55 @@
+import * as t from '@babel/types';
+
+/**
+ * A callback function for a specific node type.
+ */
+export type VisitorFn<T extends t.Node = t.Node> = (
+  node: T,
+  parent?: t.Node
+) => void;
+
+/**
+ * Callbacks for visiting AST nodes.
+ */
+export type Visitor = {
+  [Type in t.Node['type']]?: VisitorFn<Extract<t.Node, { type: Type }>>;
+};
+
+type QueueItem = [parent: t.Node | undefined, node: t.Node];
+
+/**
+ * Traverse `ast` with `visitor`. Similar to `@babel/traverse` but much simpler.
+ */
+export function traverse(ast: t.File, visitor: Visitor): void {
+  const queue: Array<QueueItem> = [[undefined, ast]];
+
+  while (queue.length) {
+    const next = queue.shift();
+
+    if (next) {
+      const [parent, node] = next;
+      const { type } = node;
+
+      if (type in visitor) {
+        const visitorFn = visitor[type] as VisitorFn;
+        visitorFn(node as t.Node, parent);
+      }
+
+      if (!(type in t.NODE_FIELDS)) {
+        continue;
+      }
+
+      const fields = Object.keys(t.NODE_FIELDS[type]);
+
+      for (const field of fields) {
+        const value = node[field];
+
+        if (Array.isArray(value)) {
+          queue.push(...value.map<QueueItem>((child) => [node, child]));
+        } else if (value) {
+          queue.push([node, value]);
+        }
+      }
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "strict": true,
     "target": "es2015",
     "declaration": true,
+    "module": "esnext",
     "moduleResolution": "node",
     "lib": ["es2015"],
     "outDir": "build",
@@ -15,7 +16,6 @@
     "noFallthroughCasesInSwitch": true,
     "suppressImplicitAnyIndexErrors": true,
     "downlevelIteration": true,
-    "esModuleInterop": true,
     "skipLibCheck": true
   },
   "include": ["src"],


### PR DESCRIPTION
NodeJS has heuristics for how to expose CommonJS exports to `import`ers, and `@babel/traverse` does not end up with its default export mapped to the default import. Rather than working around this in a weird way, let's just implement a basic `traverse` since we don't need all that `@babel/traverse` anyway.